### PR TITLE
Simply Katmaps API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ These are features added on top of the Google Maps SDK.
 	    android:value="YOUR_GOOGLE_MAPS_API_KEY_HERE"/>
 	```
 
-4. Create instance of `KatMapsFragment`
+4. Create instance of `MapFragment`
 
 	```kotlin
-	private val katmaps = KatMapsFragment()
+	private val katmaps = MapFragment()
 	```
 
-5. Add fragment to your layout with `KatMapsFragment`
+5. Add fragment to your layout with `MapFragment`
 
 	```kotlin
 	supportFragmentManager.beginTransaction().add(R.id.katmapsMap, katmaps).commit()
@@ -96,9 +96,9 @@ Once you have KatMaps set up, you can begin manipulating the map. Here are some 
 ### Setting markers
 
 ```kotlin
-val pinIcon = KatMapsIcon.Image(someBitmap)
+val pinIcon = MapIcon.Image(someBitmap)
 val sevenWonders = listOf(
-	KatMapsMarker(
+	MapMarker(
 		tag = "Great Wall",
 		position = GeoCoordinate(1.0, 1.0),
 		icon = pinIcon,

--- a/README.md
+++ b/README.md
@@ -69,17 +69,25 @@ These are features added on top of the Google Maps SDK.
 	    android:name="com.google.android.geo.API_KEY"
 	    android:value="YOUR_GOOGLE_MAPS_API_KEY_HERE"/>
 	```
+4. Create a layout with FrameLayout as the placeholder for the `MapFragment` that we'll be adding later
 
-4. Create instance of `MapFragment`
-
-	```kotlin
-	private val katmaps = MapFragment()
+	```xml
+	<FrameLayout
+		android:id="@+id/mapPlaceholder"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent" />
 	```
 
-5. Add fragment to your layout with `MapFragment`
+5. Create instance of `MapFragment` in your activity
 
 	```kotlin
-	supportFragmentManager.beginTransaction().add(R.id.katmapsMap, katmaps).commit()
+	private val map = MapFragment()
+	```
+
+5. Add fragment to `mapPlaceholder` in your layout with the `MapFragment` object we just created
+
+	```kotlin
+	supportFragmentManager.beginTransaction().add(R.id.katmaps, mapPlaceholder).commit()
 	```
 
 6. You are now ready to use KatMaps
@@ -106,19 +114,19 @@ val sevenWonders = listOf(
 	)
 )
 
-katmaps.markers = sevenWonders
+map.markers = sevenWonders
 ```
 
 ### Removing all markers
 
 ```kotlin
-katmaps.markers = emptyList()
+map.markers = emptyList()
 ```
 
 ### Setting the marker click listener
 
 ```kotlin
-katmaps.onMarkerClickListener = { marker ->
+map.onMarkerClickListener = { marker ->
     Log.i("Demo", "Clicked: ${marker.labelTitle} - ${marker.labelDescription}")
 }
 ```
@@ -126,8 +134,7 @@ katmaps.onMarkerClickListener = { marker ->
 ### Setting the marker deselected listener
 
 ```kotlin
-
-katmaps.onMarkerDeselectedListener = { marker ->
+map.onMarkerDeselectedListener = { marker ->
     Log.i("Demo", "Deselected: ${marker.labelTitle} - ${marker.labelDescription}")
 }
 ```
@@ -135,7 +142,7 @@ katmaps.onMarkerDeselectedListener = { marker ->
 ### Setting the map's position (simple)
 
 ```kotlin
-katmaps.cameraPosition = MapBounds.fromCenter(
+map.cameraPosition = MapBounds.fromCenter(
     center = GeoCoordinate(41.9019876, -87.6561932),
     radius = 2.miles
 )
@@ -146,15 +153,15 @@ katmaps.cameraPosition = MapBounds.fromCenter(
 Note: You must check for permissions or this won't work
 
 ```kotlin
-katmaps.showCurrentLocation = true
+map.showCurrentLocation = true
 ```
 
 ### Get/Set camera position via property
 
 ```kotlin
-val previousCameraPosition: MapBound = katmaps.cameraPosition
+val previousCameraPosition: MapBound = map.cameraPosition
 
-katmaps.cameraPosition = MapBounds.fromCenter(
+map.cameraPosition = MapBounds.fromCenter(
     center = previousCameraPosition.center,
     radius = 2.miles,
     tilt = 30f
@@ -164,7 +171,7 @@ katmaps.cameraPosition = MapBounds.fromCenter(
 ### Setting the map's position with/without animation via function
 
 ```kotlin
-katmaps.moveCamera(
+map.moveCamera(
     mapBounds = MapBounds.fromCenter(
         center = GeoCoordinate(41.9019876, -87.6561932),
         radius = 2.miles
@@ -176,7 +183,7 @@ katmaps.moveCamera(
 ### Show a 2 mile radius with 10% padding from all edges
 
 ```kotlin
-katmaps.cameraPosition = MapBounds.fromCenter(
+map.cameraPosition = MapBounds.fromCenter(
     center = GeoCoordinate(41.9019876, -87.6561932),
     radius = 2.miles,
     padding = MapBounds.Padding(0.1f, 0.1f, 0.1f, 0.1f)
@@ -186,7 +193,7 @@ katmaps.cameraPosition = MapBounds.fromCenter(
 ### Show exactly 2 miles accounting for 20% of the map's bottom covered
 
 ```kotlin
-katmaps.cameraPosition = MapBounds.fromCenter(
+map.cameraPosition = MapBounds.fromCenter(
     center = GeoCoordinate(41.9019876, -87.6561932),
     radius = 2.miles,
     padding = MapBounds.Padding(0f, 0.2f, 0f, 0f)
@@ -200,8 +207,8 @@ katmaps.cameraPosition = MapBounds.fromCenter(
 	
 		```xml
 		<meta-data
-		android:name="com.google.android.geo.API_KEY"
-		android:value="PUT_YOUR_KEY_HERE"/>
+			android:name="com.google.android.geo.API_KEY"
+			android:value="PUT_YOUR_KEY_HERE"/>
 		```
 	
 	- Add to your environment variable: 

--- a/demo-app/src/main/java/com/groupon/katmaps/demo/MapDataSource.kt
+++ b/demo-app/src/main/java/com/groupon/katmaps/demo/MapDataSource.kt
@@ -27,15 +27,15 @@ import android.graphics.PaintFlagsDrawFilter
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.VectorDrawable
-import com.groupon.katmaps.katmaps_library.model.KatMapsIcon
-import com.groupon.katmaps.katmaps_library.model.KatMapsMarker
+import com.groupon.katmaps.katmaps_library.model.MapIcon
+import com.groupon.katmaps.katmaps_library.model.MapMarker
 import com.groupon.katmaps.katmaps_library.model.GeoCoordinate
 
 object MapDataSource {
     private val context = KatMapsDemoApplication.appContext
     private val resources = context.resources
 
-    val pinIcon = KatMapsIcon.AnimatedImage.create(350) { scaleProgress ->
+    val pinIcon = MapIcon.AnimatedImage.create(350) { scaleProgress ->
         val normalScale = 3f
         val expandedScale = 4.5f
         val scaleDelta = expandedScale - normalScale
@@ -45,56 +45,56 @@ object MapDataSource {
     }
 
     var markers = listOf(
-        KatMapsMarker(
+        MapMarker(
             tag = "Great Wall",
             position = GeoCoordinate(40.440037, 116.568343),
             icon = pinIcon,
             labelTitle = "Great Wall of China",
             labelDescription = "First wonder of the world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Petra",
             position = GeoCoordinate(30.328547, 35.444433),
             icon = pinIcon,
             labelTitle = "Petra",
             labelDescription = "Second wonder of the world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Christ",
             position = GeoCoordinate(-22.951807, -43.210584),
             icon = pinIcon,
             labelTitle = "Christ the Redeemer",
             labelDescription = "Third wonder of the  world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Machu",
             position = GeoCoordinate(-13.158054, -72.546828),
             icon = pinIcon,
             labelTitle = "Machu Picchu",
             labelDescription = "Fourth wonder of the world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Chichen",
             position = GeoCoordinate(20.684418, -88.567735),
             icon = pinIcon,
             labelTitle = "Chichen Itza",
             labelDescription = "Fifth wonder of the world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Colosseum",
             position = GeoCoordinate(41.890298, 12.492252),
             icon = pinIcon,
             labelTitle = "Colosseum",
             labelDescription = "Sixth wonder of the world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Taj",
             position = GeoCoordinate(27.175250, 78.042174),
             icon = pinIcon,
             labelTitle = "Taj Mahal",
             labelDescription = "Seventh wonder of the world"
         ),
-        KatMapsMarker(
+        MapMarker(
             tag = "Giza",
             position = GeoCoordinate(29.979272, 31.134213),
             icon = pinIcon,

--- a/demo-app/src/main/java/com/groupon/katmaps/demo/PoiListAdapter.kt
+++ b/demo-app/src/main/java/com/groupon/katmaps/demo/PoiListAdapter.kt
@@ -4,11 +4,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.groupon.katmaps.katmaps_library.model.KatMapsMarker
+import com.groupon.katmaps.katmaps_library.model.MapMarker
 import kotlinx.android.synthetic.main.poi_card.view.*
 
-class PoiListAdapter(private val clickListener: ((KatMapsMarker) -> Unit)) : RecyclerView.Adapter<PoiListAdapter.VH>() {
-    var items: List<KatMapsMarker> = emptyList()
+class PoiListAdapter(private val clickListener: ((MapMarker) -> Unit)) : RecyclerView.Adapter<PoiListAdapter.VH>() {
+    var items: List<MapMarker> = emptyList()
         set(value) {
             field = value
             notifyDataSetChanged()
@@ -23,11 +23,11 @@ class PoiListAdapter(private val clickListener: ((KatMapsMarker) -> Unit)) : Rec
         holder.bind(items[position])
     }
 
-    class VH(view: View, private val clickListener: ((KatMapsMarker) -> Unit)): RecyclerView.ViewHolder(view) {
-        fun bind(katmapsMarker: KatMapsMarker) {
-            itemView.poiName.text = katmapsMarker.labelTitle
-            itemView.poiDescription.text = katmapsMarker.labelDescription
-            itemView.setOnClickListener { clickListener(katmapsMarker) }
+    class VH(view: View, private val clickListener: ((MapMarker) -> Unit)): RecyclerView.ViewHolder(view) {
+        fun bind(marker: MapMarker) {
+            itemView.poiName.text = marker.labelTitle
+            itemView.poiDescription.text = marker.labelDescription
+            itemView.setOnClickListener { clickListener(marker) }
         }
     }
 }

--- a/demo-app/src/main/java/com/groupon/katmaps/demo/PoisBottomSheet.kt
+++ b/demo-app/src/main/java/com/groupon/katmaps/demo/PoisBottomSheet.kt
@@ -25,15 +25,15 @@ import android.widget.FrameLayout
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView.VERTICAL
-import com.groupon.katmaps.katmaps_library.model.KatMapsMarker
+import com.groupon.katmaps.katmaps_library.model.MapMarker
 import kotlinx.android.synthetic.main.pois_list_bottom_sheet.view.*
 
 class PoisBottomSheet(context: Context, attributeSet: AttributeSet?) :
     FrameLayout(context, attributeSet) {
 
-    private val itemClickListenerInternal: ((KatMapsMarker) -> Unit) = { itemClickListener?.invoke(it) }
+    private val itemClickListenerInternal: ((MapMarker) -> Unit) = { itemClickListener?.invoke(it) }
     private var poiListAdapter: PoiListAdapter = PoiListAdapter(itemClickListenerInternal)
-    var itemClickListener: ((KatMapsMarker) -> Unit)? = null
+    var itemClickListener: ((MapMarker) -> Unit)? = null
 
     init {
         inflate(context, R.layout.pois_list_bottom_sheet, this)

--- a/demo-app/src/main/res/layout/activity_main.xml
+++ b/demo-app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
     tools:context=".MainActivity">
 
   <FrameLayout
-      android:id="@+id/map"
+      android:id="@+id/mapPlaceholder"
       android:layout_width="match_parent"
       android:layout_height="match_parent" />
 

--- a/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/MapFragment.kt
+++ b/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/MapFragment.kt
@@ -30,7 +30,7 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.groupon.katmaps.katmaps_library.model.GeoCoordinate
-import com.groupon.katmaps.katmaps_library.model.KatMapsMarker
+import com.groupon.katmaps.katmaps_library.model.MapMarker
 import com.groupon.katmaps.katmaps_library.model.MapBounds
 import com.groupon.katmaps.katmaps_library.model.MarkerViewState
 import com.groupon.katmaps.katmaps_library.model.MovementReason
@@ -45,7 +45,7 @@ import com.groupon.katmaps.katmaps_library.views.InternalMapView
 /**
  * KatMaps Map Fragment
  */
-class KatMapsFragment : Fragment() {
+class MapFragment : Fragment() {
     companion object {
         private const val LABEL_HIDE_THROTTLING_MS = 100
     }
@@ -53,7 +53,7 @@ class KatMapsFragment : Fragment() {
     private var googleMap: GoogleMap? = null
     private lateinit var googleMapView: MapView
     private var markersMap = HashMap<Any, MapMarkerContainer>()
-    private var deferredMarkers = emptyList<KatMapsMarker>()
+    private var deferredMarkers = emptyList<MapMarker>()
     private var deferredSelectedTag: Any? = null
     private var selectedMarker: MapMarkerContainer? = null
     private var deferredCameraPosition: MapBounds? = null
@@ -75,8 +75,8 @@ class KatMapsFragment : Fragment() {
 
     var onMapClickListener: ((GeoCoordinate) -> Unit)? = null
     var onMapLongClickListener: ((GeoCoordinate) -> Unit)? = null
-    var onMarkerClickListener: ((KatMapsMarker) -> Unit)? = null
-    var onMarkerDeselectedListener: ((KatMapsMarker) -> Unit)? = null
+    var onMarkerClickListener: ((MapMarker) -> Unit)? = null
+    var onMarkerDeselectedListener: ((MapMarker) -> Unit)? = null
     var onMapCameraMoveListener: ((MovementState, MovementReason) -> Unit)? = null
 
     var cameraPosition: MapBounds?
@@ -109,8 +109,8 @@ class KatMapsFragment : Fragment() {
             field = value
         }
 
-    var markers: List<KatMapsMarker>
-        get() = markersMap.values.map { it.katmapsMarker }
+    var markers: List<MapMarker>
+        get() = markersMap.values.map { it.marker }
         set(value) {
             googleMap.run {
                 if (this == null) {
@@ -135,7 +135,7 @@ class KatMapsFragment : Fragment() {
                 selectMapMarker(marker)
             }
         }
-        get() = selectedMarker?.katmapsMarker?.tag
+        get() = selectedMarker?.marker?.tag
 
     var areAllGesturesEnabled: Boolean = true
         set(value) {
@@ -227,7 +227,7 @@ class KatMapsFragment : Fragment() {
         }
     }
 
-    fun getKatMapsMarkerFromTag(tag: Any): KatMapsMarker? = markersMap[tag]?.katmapsMarker
+    fun getMarkerFromTag(tag: Any): MapMarker? = markersMap[tag]?.marker
 
     fun screenLocationOf(coordinate: GeoCoordinate): Point? = googleMap?.projection?.toScreenLocation(coordinate.latLng)
 
@@ -274,10 +274,10 @@ class KatMapsFragment : Fragment() {
         }
     }
 
-    private fun handleGoogleMarkerClick(marker: KatMapsMarker): Boolean {
+    private fun handleGoogleMarkerClick(marker: MapMarker): Boolean {
         val clickedMarker = markersMap[marker.tag] ?: return true
         selectMapMarker(clickedMarker)
-        onMarkerClickListener?.invoke(clickedMarker.katmapsMarker)
+        onMarkerClickListener?.invoke(clickedMarker.marker)
         return true
     }
 
@@ -298,11 +298,11 @@ class KatMapsFragment : Fragment() {
         deselectedMarker.viewState = MarkerViewState.PIN_ONLY // The label will get shown if needed on the next round of hideLabelsWhenOverlap()
 
         selectedMarker = null
-        onMarkerDeselectedListener?.invoke(deselectedMarker.katmapsMarker)
+        onMarkerDeselectedListener?.invoke(deselectedMarker.marker)
     }
 
     private fun removeAllMarkers() {
-        selectedMarker?.let { onMarkerDeselectedListener?.invoke(it.katmapsMarker) }
+        selectedMarker?.let { onMarkerDeselectedListener?.invoke(it.marker) }
         selectedMarker = null
         markersMap.values.forEach { it.remove() }
         markersMap.clear()

--- a/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/MapMarkerContainer.kt
+++ b/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/MapMarkerContainer.kt
@@ -30,8 +30,8 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
-import com.groupon.katmaps.katmaps_library.model.KatMapsIcon
-import com.groupon.katmaps.katmaps_library.model.KatMapsMarker
+import com.groupon.katmaps.katmaps_library.model.MapIcon
+import com.groupon.katmaps.katmaps_library.model.MapMarker
 import com.groupon.katmaps.katmaps_library.model.MarkerViewState
 import com.groupon.katmaps.katmaps_library.model.getSize
 import com.groupon.katmaps.katmaps_library.model.latLng
@@ -45,7 +45,7 @@ import kotlinx.android.synthetic.main.map_marker_label.view.*
 internal class MapMarkerContainer(
     context: Context,
     googleMap: GoogleMap,
-    val katmapsMarker: KatMapsMarker
+    val marker: MapMarker
 ) {
     companion object {
         internal const val MARKER_LABEL_HORIZONTAL_ANCHOR = 0.5f
@@ -72,9 +72,9 @@ internal class MapMarkerContainer(
     private var animationTimer: Timer? = null
 
     init {
-        labelBitmap = generateMapLabelBitmap(context, katmapsMarker)
-        mapPin = createMapMarker(googleMap, katmapsMarker)
-        mapLabel = createMapLabel(googleMap, katmapsMarker, labelBitmap)
+        labelBitmap = generateMapLabelBitmap(context, marker)
+        mapPin = createMapMarker(googleMap, marker)
+        mapLabel = createMapLabel(googleMap, marker, labelBitmap)
     }
 
     fun remove() {
@@ -84,19 +84,19 @@ internal class MapMarkerContainer(
     }
 
     fun getPinBounds(googleMap: GoogleMap, resources: Resources): Rect {
-        val pinSize = katmapsMarker.icon.getSize(viewState == MarkerViewState.EXPANDED_WITH_LABEL)
-
-        val pinAnchorCoordinate = googleMap.projection.toScreenLocation(katmapsMarker.position.latLng)
+        val pinSize = marker.icon.getSize(viewState == MarkerViewState.EXPANDED_WITH_LABEL)
+        val pinAnchorCoordinate = googleMap.projection.toScreenLocation(marker.position.latLng)
 
         val labelLeft = (pinAnchorCoordinate.x - pinSize.width() / 2).pxToDp(resources)
         val labelRight = (pinAnchorCoordinate.x + pinSize.width() / 2).pxToDp(resources)
         val labelTop = (pinAnchorCoordinate.y - pinSize.height()).pxToDp(resources)
         val labelBottom = pinAnchorCoordinate.y.pxToDp(resources)
+
         return Rect(labelLeft, labelTop, labelRight, labelBottom)
     }
 
     fun getLabelBounds(googleMap: GoogleMap, resources: Resources): Rect? {
-        val labelAnchorCoordinate = googleMap.projection.toScreenLocation(katmapsMarker.position.latLng)
+        val labelAnchorCoordinate = googleMap.projection.toScreenLocation(marker.position.latLng)
 
         return labelBitmap?.run {
             val labelLeft = (labelAnchorCoordinate.x - labelBitmap.width / 2).pxToDp(resources)
@@ -108,13 +108,13 @@ internal class MapMarkerContainer(
     }
 
     private fun animateExpansion(viewState: MarkerViewState) {
-        if (katmapsMarker.icon !is KatMapsIcon.AnimatedImage) {
+        if (marker.icon !is MapIcon.AnimatedImage) {
             return
         }
 
-        val interval = TimeUnit.SECONDS.toMillis(1) / KatMapsIcon.AnimatedImage.FRAME_RATE
-        val frames = katmapsMarker.icon.images.map { BitmapDescriptorFactory.fromBitmap(it) }
-        val numFrames = katmapsMarker.icon.images.size
+        val interval = TimeUnit.SECONDS.toMillis(1) / MapIcon.AnimatedImage.FRAME_RATE
+        val frames = marker.icon.images.map { BitmapDescriptorFactory.fromBitmap(it) }
+        val numFrames = marker.icon.images.size
 
         animationTimer?.cancel()
 
@@ -126,35 +126,35 @@ internal class MapMarkerContainer(
         }
     }
 
-    private fun createMapMarker(googleMap: GoogleMap, katmapsMarker: KatMapsMarker): Marker {
-        val iconBitmap = when (val asset = katmapsMarker.icon) {
-            is KatMapsIcon.Image -> BitmapDescriptorFactory.fromBitmap(asset.image)
-            is KatMapsIcon.AnimatedImage -> BitmapDescriptorFactory.fromBitmap(asset.images.first())
+    private fun createMapMarker(googleMap: GoogleMap, marker: MapMarker): Marker {
+        val iconBitmap = when (val asset = marker.icon) {
+            is MapIcon.Image -> BitmapDescriptorFactory.fromBitmap(asset.image)
+            is MapIcon.AnimatedImage -> BitmapDescriptorFactory.fromBitmap(asset.images.first())
         }
 
         val marker = googleMap.addMarker(
             MarkerOptions()
-                .position(katmapsMarker.position.latLng)
+                .position(marker.position.latLng)
                 .icon(iconBitmap)
         )
-        marker.tag = katmapsMarker.tag
+        marker.tag = marker.tag
         return marker
     }
 
-    private fun createMapLabel(googleMap: GoogleMap, katmapsMarker: KatMapsMarker, labelBitmap: Bitmap): Marker? {
-        if (katmapsMarker.labelTitle.isEmpty() && katmapsMarker.labelDescription.isEmpty()) return null
+    private fun createMapLabel(googleMap: GoogleMap, marker: MapMarker, labelBitmap: Bitmap): Marker? {
+        if (marker.labelTitle.isEmpty() && marker.labelDescription.isEmpty()) return null
 
         val label = googleMap.addMarker(
             MarkerOptions()
-                .position(katmapsMarker.position.latLng)
+                .position(marker.position.latLng)
                 .icon(BitmapDescriptorFactory.fromBitmap(labelBitmap))
                 .anchor(MARKER_LABEL_HORIZONTAL_ANCHOR, MARKER_LABEL_VERTICAL_ANCHOR)
         )
-        label.tag = katmapsMarker.tag
+        label.tag = marker.tag
         return label
     }
 
-    private fun generateMapLabelBitmap(context: Context, katmapsMarker: KatMapsMarker): Bitmap {
+    private fun generateMapLabelBitmap(context: Context, katmapsMarker: MapMarker): Bitmap {
         return LayoutInflater.from(context).inflate(R.layout.map_marker_label, null).apply {
             markerLabelTitle.text = katmapsMarker.labelTitle
             markerLabelDescription.text = katmapsMarker.labelDescription

--- a/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/model/MapIcon.kt
+++ b/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/model/MapIcon.kt
@@ -25,12 +25,12 @@ import android.graphics.Rect
 import android.view.animation.AnticipateOvershootInterpolator
 import java.util.concurrent.TimeUnit
 
-sealed class KatMapsIcon {
+sealed class MapIcon {
     /**
      * Define a static icon
      * @param image the icon in Bitmap format
      */
-    data class Image(val image: Bitmap) : KatMapsIcon()
+    data class Image(val image: Bitmap) : MapIcon()
 
     /**
      * Define an animated icon
@@ -38,7 +38,7 @@ sealed class KatMapsIcon {
      * @param duration time in milliseconds to playback the animations
      * @param expanded the state of animation. False = playback in reverse from the end. True = playback forward from the beginning.
      */
-    data class AnimatedImage(val images: List<Bitmap>, val duration: Long, var expanded: Boolean) : KatMapsIcon() {
+    data class AnimatedImage(val images: List<Bitmap>, val duration: Long, var expanded: Boolean) : MapIcon() {
         companion object {
             const val FRAME_RATE = 60L
 
@@ -67,9 +67,9 @@ sealed class KatMapsIcon {
     }
 }
 
-fun KatMapsIcon.getSize(isExpanded: Boolean) = when (this) {
-    is KatMapsIcon.Image -> Rect(0, 0, image.width, image.height)
-    is KatMapsIcon.AnimatedImage -> {
+fun MapIcon.getSize(isExpanded: Boolean) = when (this) {
+    is MapIcon.Image -> Rect(0, 0, image.width, image.height)
+    is MapIcon.AnimatedImage -> {
         // get the largest (last) frame if expanded, otherwise get the smallest (first) frame if default size
         val image = if (isExpanded) images.last() else images.first()
         Rect(0, 0, image.width, image.height)

--- a/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/model/MapMarker.kt
+++ b/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/model/MapMarker.kt
@@ -27,10 +27,10 @@ package com.groupon.katmaps.katmaps_library.model
  * @param labelTitle a text label under the marker with a title
  * @param labelDescription a text label under the marker with a description
  */
-data class KatMapsMarker(
+data class MapMarker(
     val tag: Any,
     var position: GeoCoordinate,
-    val icon: KatMapsIcon,
+    val icon: MapIcon,
     var labelTitle: String = "",
     var labelDescription: String = ""
 )

--- a/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/util/MapObjectSelectionHelper.kt
+++ b/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/util/MapObjectSelectionHelper.kt
@@ -25,7 +25,7 @@ import android.graphics.Rect
 import com.google.android.gms.maps.GoogleMap
 import com.groupon.katmaps.katmaps_library.MapMarkerContainer
 import com.groupon.katmaps.katmaps_library.model.GeoCoordinate
-import com.groupon.katmaps.katmaps_library.model.KatMapsMarker
+import com.groupon.katmaps.katmaps_library.model.MapMarker
 import com.groupon.katmaps.katmaps_library.model.latLng
 
 internal class MapObjectSelectionHelper(
@@ -41,10 +41,10 @@ internal class MapObjectSelectionHelper(
 
     private fun GoogleMap.screenLocationOf(coordinate: GeoCoordinate): Point? = this.projection.toScreenLocation(coordinate.latLng)
 
-    private val previousTouchedMarkers: LinkedHashSet<KatMapsMarker> = LinkedHashSet()
-    private val toggledMarkers: HashSet<KatMapsMarker> = HashSet()
+    private val previousTouchedMarkers: LinkedHashSet<MapMarker> = LinkedHashSet()
+    private val toggledMarkers: HashSet<MapMarker> = HashSet()
 
-    fun findMarkerToSelect(mapTouchPosition: Point): KatMapsMarker? {
+    fun findMarkerToSelect(mapTouchPosition: Point): MapMarker? {
         val currentMarkersTouched = findMarkersTouched(mapTouchPosition)
 
         val currentMarkersTouchedCount = currentMarkersTouched.count()
@@ -52,28 +52,28 @@ internal class MapObjectSelectionHelper(
             return null
         }
 
-        val markerToSelect: KatMapsMarker?
+        val markerToSelect: MapMarker?
         val setSimilarity = (currentMarkersTouched - previousTouchedMarkers).count().toFloat() / currentMarkersTouchedCount
         if (setSimilarity > SET_SIMILARITY_THRESHOLD) {
             // Similar set, cycle between markers
-            val nextToSelect = currentMarkersTouched.find { !toggledMarkers.contains(it.katmapsMarker) }
+            val nextToSelect = currentMarkersTouched.find { !toggledMarkers.contains(it.marker) }
             markerToSelect = if (nextToSelect == null) {
                 // Restart cycling
                 toggledMarkers.clear()
-                toggledMarkers.add(currentMarkersTouched.first().katmapsMarker)
-                currentMarkersTouched.first().katmapsMarker
+                toggledMarkers.add(currentMarkersTouched.first().marker)
+                currentMarkersTouched.first().marker
             } else {
                 // move on to next marker
-                toggledMarkers.add(nextToSelect.katmapsMarker)
-                nextToSelect.katmapsMarker
+                toggledMarkers.add(nextToSelect.marker)
+                nextToSelect.marker
             }
         } else {
             // New set, select marker
             toggledMarkers.clear()
-            markerToSelect = currentMarkersTouched.first().katmapsMarker
+            markerToSelect = currentMarkersTouched.first().marker
         }
         previousTouchedMarkers.clear()
-        previousTouchedMarkers.addAll(currentMarkersTouched.map { it.katmapsMarker })
+        previousTouchedMarkers.addAll(currentMarkersTouched.map { it.marker })
         return markerToSelect
     }
 
@@ -87,7 +87,7 @@ internal class MapObjectSelectionHelper(
             .asSequence()
             .filter { Rect.intersects(clickBox, it.getPinBounds(map, resources)) }
             .mapNotNull { markerContainer ->
-                val screenLocation = map.screenLocationOf(markerContainer.katmapsMarker.position)
+                val screenLocation = map.screenLocationOf(markerContainer.marker.position)
                 if (screenLocation != null) Pair(markerContainer, distance(mapTouchPosition, screenLocation)) else null
             }
             .sortedBy { it.second }


### PR DESCRIPTION
## Proposed Change
KatMaps is currently awkward to use with the long and pretentious class names and models. I simplified it by removing KatMaps from the prefix of most classes.