### PR TITLE
Updated Gradle, Android Gradle, Kotlin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.3.72'
+  ext.kotlin_version = '1.4.21'
   repositories {
     google()
     jcenter()
@@ -10,7 +10,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.0.0'
+    classpath 'com.android.tools.build:gradle:4.1.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
     // Ktlint

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip


### PR DESCRIPTION
- Upgraded Kotlin version to the latest Android Studio supported version from `1.3.72` to `1.4.21`
- Upgraded Android Gradle plugin from `4.0.0` to `4.1.2`
- Upgraded Gradle version from `6.1.1` to `6.8.1`