### PR TITLE
Properly set Google Map marker's tag with the KatMaps tag

### DIFF
--- a/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/MapMarkerContainer.kt
+++ b/katmaps-library/src/main/java/com/groupon/katmaps/katmaps_library/MapMarkerContainer.kt
@@ -132,14 +132,14 @@ internal class MapMarkerContainer(
             is MapIcon.AnimatedImage -> BitmapDescriptorFactory.fromBitmap(asset.images.first())
         }
 
-        val marker = googleMap.addMarker(
+        val googleMarker = googleMap.addMarker(
             MarkerOptions()
                 .position(marker.position.latLng)
                 .icon(iconBitmap)
                 .title(marker.labelTitle + " " + marker.labelDescription)
         )
-        marker.tag = marker.tag
-        return marker
+        googleMarker.tag = marker.tag
+        return googleMarker
     }
 
     private fun createMapLabel(googleMap: GoogleMap, marker: MapMarker, labelBitmap: Bitmap): Marker? {


### PR DESCRIPTION
The Google Marker tag was set incorrectly in `MapMarkerContainer.createMapMarker()`. The consequence of this is that Google Maps will assume that all markers are the same, causing all markers on the map to be associated with one another. This was inadventently changed in a refactor: https://github.com/groupon/KatMaps/commit/42f73ff5b7474fbb2dba239b7015039b5e4cc2f0

Thanks to @ahinchman1 for discovering this bug!